### PR TITLE
Include vbproj files when scanning

### DIFF
--- a/IntegrationTest/VerifyProcess.cs
+++ b/IntegrationTest/VerifyProcess.cs
@@ -51,7 +51,7 @@ namespace IntegrationTest
             string path = Directory.GetCurrentDirectory() + subpath;
             var lines = File.ReadAllLines(path + "/TestProject.csproj");
             var sut = new RemoveOldNugetRestore(Command);
-            var outlines = sut.FixImportAndRestorePackagesInCsproj(lines, path + "/TestProject.csproj");
+            var outlines = sut.FixImportAndRestorePackagesInProj(lines, path + "/TestProject.csproj");
             
             Assert.IsTrue(outlines.Count()<lines.Count());
             Assert.IsTrue(RemoveOldNugetRestore.ALineContains(lines, "RestorePackages"), "1");
@@ -68,7 +68,7 @@ namespace IntegrationTest
             var lines = File.ReadAllLines(path + "/TestProject.csproj");
 
             var sut = new RemoveOldNugetRestore(Command);
-            var outlines = sut.FixTargetInCsproj(lines);
+            var outlines = sut.FixTargetInProj(lines);
             Assert.IsTrue(lines.Count()==outlines.Count()+6);
 
         }

--- a/NugetConvert2AutomaticRestore.Setup/Wix.Generated.wxs
+++ b/NugetConvert2AutomaticRestore.Setup/Wix.Generated.wxs
@@ -14,20 +14,14 @@
             <Component Id="cmp9721F1F9E58B3B5A13113D4FFDDC760A" Guid="*">
                 <File Id="fil3E76BCDD24ACB778409414C183979E5D" KeyPath="yes" Source="$(var.AppProjectDir)\IFix.exe.config" />
             </Component>
+            <Component Id="cmp0B5CF81FFC431E8F8C8061D95CD90F32" Guid="*">
+                <File Id="fil1919D012D9726452EC0172083991370E" KeyPath="yes" Source="$(var.AppProjectDir)\IFix.pdb" />
+            </Component>
             <Component Id="cmpB2264C61EB06A2B7C056E1B0C6EC0746" Guid="*">
                 <File Id="fil372BBABA30F3A671BA85CA8E88C921E5" KeyPath="yes" Source="$(var.AppProjectDir)\IFix.vshost.exe" />
             </Component>
             <Component Id="cmp294999D218C6A6FF32C3D2A3781417EA" Guid="*">
                 <File Id="filB96B0D1614ACDA4CB34370437B4F691E" KeyPath="yes" Source="$(var.AppProjectDir)\IFix.vshost.exe.config" />
-            </Component>
-            <Component Id="cmpB8AD0F8170F3A441FCD08F0B36A1ACA3" Guid="*">
-                <File Id="fil19FE8940DF53BB37F4970CD5DE51EB4F" KeyPath="yes" Source="$(var.AppProjectDir)\IFix.vshost.exe.manifest" />
-            </Component>
-            <Component Id="cmp5AC3245B893E12B66F26E543E68A5AB5" Guid="*">
-                <File Id="filA709A0BEC8695C36092E2F17B5EBEE30" KeyPath="yes" Source="$(var.AppProjectDir)\RemoveOldNugetRestore.exe" />
-            </Component>
-            <Component Id="cmp91128CC3741BC7E93BE977481D145A4F" Guid="*">
-                <File Id="fil0AED30B2734B9C4819987DB9EC11AD01" KeyPath="yes" Source="$(var.AppProjectDir)\RemoveOldNugetRestore.exe.config" />
             </Component>
         </DirectoryRef>
     </Fragment>
@@ -37,11 +31,9 @@
             <ComponentRef Id="cmp5E3D3348D828484657D3F25D74F6957D" />
             <ComponentRef Id="cmp9C10E065CAA211E29C3F463220F708D7" />
             <ComponentRef Id="cmp9721F1F9E58B3B5A13113D4FFDDC760A" />
+            <ComponentRef Id="cmp0B5CF81FFC431E8F8C8061D95CD90F32" />
             <ComponentRef Id="cmpB2264C61EB06A2B7C056E1B0C6EC0746" />
             <ComponentRef Id="cmp294999D218C6A6FF32C3D2A3781417EA" />
-            <ComponentRef Id="cmpB8AD0F8170F3A441FCD08F0B36A1ACA3" />
-            <ComponentRef Id="cmp5AC3245B893E12B66F26E543E68A5AB5" />
-            <ComponentRef Id="cmp91128CC3741BC7E93BE977481D145A4F" />
         </ComponentGroup>
     </Fragment>
 </Wix>

--- a/RemoveOldNugetRestore/Properties/AssemblyInfo.cs
+++ b/RemoveOldNugetRestore/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.0.1")]
+[assembly: AssemblyFileVersion("1.0.0.1")]


### PR DESCRIPTION
Added vbproj files to the scanning process and also check for nuget.exe
in sln file and remove if found.  I also tweaked the checks to be case insensitive since in my files nuget.exe was all lowercase.
