### PR TITLE
gitignore template link updated from "master" to "main"

### DIFF
--- a/IFix/gitignore.cs
+++ b/IFix/gitignore.cs
@@ -340,7 +340,7 @@ namespace IFix
         {
             using (var client = new WebClient())
             {
-                client.DownloadFile("https://github.com/github/gitignore/raw/master/VisualStudio.gitignore",
+                client.DownloadFile("https://github.com/github/gitignore/raw/main/VisualStudio.gitignore",
                     path);
             }
         }


### PR DESCRIPTION
The gitignore master branch has been renamed to main, so the link hardcoded to the VisualStudio.gitignore template was broken.

Changing "master" to "main" in the link fixes this.

However might be an idea to make this link configurable somehow?